### PR TITLE
Added Part Attribute

### DIFF
--- a/src/perfect-arrow.ts
+++ b/src/perfect-arrow.ts
@@ -88,6 +88,7 @@ export class PerfectArrow extends AbstractArrow {
   protected createRenderRoot(): HTMLElement | DocumentFragment {
     const root = super.createRenderRoot();
 
+    this.#svg.setAttribute('part', 'svg-arrow');
     this.#svg.setAttribute('stroke', '#000');
     this.#svg.setAttribute('fill', '#000');
     this.#svg.setAttribute('strokeWidth', '3');


### PR DESCRIPTION
A very simple modification, just added de `part` atribute to the svg inside the shadow dom

This way you can apply CSS styles to the arrow, like that
```css
perfect-arrow::part(svg-arrow){
    fill: red;
    stroke: red;
}
```